### PR TITLE
fix: exclude tests from tsc build

### DIFF
--- a/src/target-processing.ts
+++ b/src/target-processing.ts
@@ -286,7 +286,8 @@ export async function processBatchTargets(env: Env): Promise<BatchProcessingResu
     );
 
     // Step 6: Log performance metrics (only in development/debug mode)
-    if (process.env.NODE_ENV !== 'production') {
+    const nodeEnv = (globalThis as any).process?.env?.NODE_ENV;
+    if (nodeEnv !== 'production') {
       const perfStats = monitor.getStats();
       console.log('Performance metrics:', perfStats);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- skip compiling test files during worker build
- guard performance logging against missing `process` variable

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995eca2930832dbf196d8001a17519